### PR TITLE
Compatibility fix

### DIFF
--- a/Resources/GameData/Squidsoft Collective/FuelCellTweaks/FuelCellTweaks.cfg
+++ b/Resources/GameData/Squidsoft Collective/FuelCellTweaks/FuelCellTweaks.cfg
@@ -1,4 +1,4 @@
-@PART[*]:HAS[@MODULE[ModuleResourceConverter]:HAS[#ConverterName[Fuel?Cell]]]:FINAL
+@PART[*]:HAS[@MODULE[ModuleResourceConverter]:HAS[#ConverterName[*Fuel?Cell*]]]:FINAL
 {
 	%MODULE[FuelCellTweaks]
 	{


### PR DESCRIPTION
So that "Fuel Cell" can be anywhere in the converter name, eg the fuel cell in SETIprobeParts.